### PR TITLE
merge frontend into main dir

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "frontend/cc_frontend"]
+	path = frontend/cc_frontend
+	url = https://github.com/curriculum-crawler/cc_frontend.git

--- a/.idea/curriculum-crawler.iml
+++ b/.idea/curriculum-crawler.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (cs33)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,5 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (cs33)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/frontend/cc_frontend" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
Changing the project's directory as suggested. 

See cc_frontend/README.md for instructions on how to run

Project is live on heroku at this curriculumcrawler.herokuapp.com
Github -> Heroku pipeline has not been implemented, deployment is currently only directly through Heroku CLI.
Project can be built with npm and Django's manage.py
Initial files have been set up for React, Django and Heroku Postgres.
No models exist.